### PR TITLE
add editorconfig markdown override

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,7 @@ indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
 max_line_length = 80
+
+[*.md]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Markdown typically allows using tabs instead of 4 spaces, but many features need to be space aligned anyways. This PR overrides markdown to use spaces with `.editorconfig`.