### PR TITLE
Add linear solver base class and CPU implementation

### DIFF
--- a/include/MAKAsolve/LinearSolver.h
+++ b/include/MAKAsolve/LinearSolver.h
@@ -1,0 +1,33 @@
+#ifndef MAKASOLVE_LINEARSOLVER_H
+#define MAKASOLVE_LINEARSOLVER_H
+
+#include <exception>
+#include <memory>
+#include <stdexcept>
+
+#include <mth.h>
+
+namespace maka {
+
+/**
+ * \brief Abstract linear solver base class.
+ */
+class LinearSolver {
+public:
+	virtual void solve(const mth::Matrix<double>& A, const mth::Vector<double>& b,
+										 mth::Vector<double>& x) = 0;
+	virtual ~LinearSolver() = 0;
+};
+
+class LinearException : public std::runtime_error {
+public:
+	using std::runtime_error::runtime_error;
+};
+
+using LinearSolverPtr = std::unique_ptr<LinearSolver>;
+
+LinearSolverPtr makeCPULinearSolver();
+
+} // namespace maka
+
+#endif // MAKASOLVE_LINEARSOLVER_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(SOURCES
 	MAKAsolve.cc
 	Input.cc
+	LinearSolver.cc
+	CPULinearSolver.cc
 )
 
 add_library(MAKAsolve ${SOURCES})

--- a/src/CPULinearSolver.cc
+++ b/src/CPULinearSolver.cc
@@ -1,0 +1,32 @@
+#include <MAKAsolve/LinearSolver.h>
+
+#include <mthQR.h>
+
+namespace maka {
+
+class CPULinearSolver : public LinearSolver {
+public:
+	void solve(const mth::Matrix<double>& A, const mth::Vector<double>& b,
+						 mth::Vector<double>& x) override;
+	virtual ~CPULinearSolver();
+};
+
+void CPULinearSolver::solve(const mth::Matrix<double>& A, const
+		mth::Vector<double>& b,
+														mth::Vector<double>& x) {
+	x.resize(A.cols());
+	bool solved = mth::solveQR(A, b, x);
+	if (!solved) throw LinearException("CPULinearSolver: failed to solve system");
+}
+
+CPULinearSolver::~CPULinearSolver() {}
+
+LinearSolverPtr makeCPULinearSolver() {
+#if __cplusplus >= 201304L
+	return std::make_unique<CPULinearSolver>();
+#else
+	return std::unique_ptr<CPULinearSolver>(new CPULinearSolver);
+#endif
+}
+
+} // namespace maka

--- a/src/CPULinearSolver.cc
+++ b/src/CPULinearSolver.cc
@@ -11,8 +11,8 @@ public:
 	virtual ~CPULinearSolver();
 };
 
-void CPULinearSolver::solve(const mth::Matrix<double>& A, const
-		mth::Vector<double>& b,
+void CPULinearSolver::solve(const mth::Matrix<double>& A,
+														const mth::Vector<double>& b,
 														mth::Vector<double>& x) {
 	x.resize(A.cols());
 	bool solved = mth::solveQR(A, b, x);

--- a/src/LinearSolver.cc
+++ b/src/LinearSolver.cc
@@ -3,6 +3,6 @@
 namespace maka {
 
 // note: definition required for pure virtual destructor
-LinearSolver::~LinearSolver () {}
+LinearSolver::~LinearSolver() {}
 
 } // namespace maka

--- a/src/LinearSolver.cc
+++ b/src/LinearSolver.cc
@@ -1,0 +1,8 @@
+#include <MAKAsolve/LinearSolver.h>
+
+namespace maka {
+
+// note: definition required for pure virtual destructor
+LinearSolver::~LinearSolver () {}
+
+} // namespace maka

--- a/test/stiffness.cc
+++ b/test/stiffness.cc
@@ -13,7 +13,8 @@
 #include <gmi_mesh.h>
 #include <lionPrint.h>
 #include <ma.h>
-#include <mthQR.h>
+
+#include <MAKAsolve/LinearSolver.h>
 
 void print_exception(const std::exception& e, int level = 0);
 void addDirichletBCs(apf::Numbering* nbr, int model_dim, int model_tag,
@@ -105,8 +106,8 @@ int main(int argc, char* argv[]) {
 		if (refinement == 0) std::cout << "K: " << K << "F: " << F << '\n';
 		// Obtain solution.
 		mth::Vector<double> phi_full(num_nodes);
-		bool solved = mth::solveQR(K, F, phi_full);
-		if (!solved) throw std::runtime_error("failed to solve system");
+		auto CPUsolver = maka::makeCPULinearSolver();
+		CPUsolver->solve(K, F, phi_full);
 		if (refinement == 0) std::cout << "phi: " << phi_full << '\n';
 		apf::DynamicArray<apf::Node> nodes;
 		apf::getNodes(nbr, nodes);


### PR DESCRIPTION
This PR adds a `maka::LinearSolver` base class that the CPU and GPU solvers can inherit from.